### PR TITLE
Record Nextclade and Pangolin versions

### DIFF
--- a/susCovONT.py
+++ b/susCovONT.py
@@ -468,8 +468,7 @@ def get_nextclade_command(run_name,consensus_dir,nextclade_ver,nextclade_data_ve
                      ' --output-csv=\'/seq/nextclade.csv\''
                      ' --output-all=seq/data/nextclade'
                      ' --jobs=',str(cpus),' ; '
-                     'mv ',consensus_dir,'nextclade.csv ',nextclade_outdir,
-                     ' & >> ',nextclade_outdir,'nextclade_log.txt ; '
+                     'mv ',consensus_dir,'nextclade.csv ',nextclade_outdir,' ; '
                      'mv ',consensus_dir,'data/nextclade ',nextclade_outdir,' ; ']
 
     #Move tag file to record which nextclade database tag/version was used

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -470,8 +470,10 @@ def get_nextclade_command(run_name,consensus_dir,nextclade_ver,nextclade_data_ve
                      ' --jobs=',str(cpus),' ; '
                      'mv ',consensus_dir,'nextclade.csv ',nextclade_outdir,
                      ' & >> ',nextclade_outdir,'nextclade_log.txt ; '
-                     'mv ',consensus_dir,'data/nextclade ',nextclade_outdir]
+                     'mv ',consensus_dir,'data/nextclade ',nextclade_outdir,' ; ']
 
+    #Move tag file to record which nextclade database tag/version was used
+    nextclade_command += ['mv ',consensus_dir,'/data/sars-cov-2/tag.json ',nextclade_outdir,'/nextclade-tag.json']
 
     print(combineCommand(nextclade_command))
     return nextclade_command

--- a/susCovONT.py
+++ b/susCovONT.py
@@ -467,12 +467,12 @@ def get_nextclade_command(run_name,consensus_dir,nextclade_ver,nextclade_data_ve
                      ' /seq/',consensus_base,''
                      ' --output-csv=\'/seq/nextclade.csv\''
                      ' --output-all=seq/data/nextclade'
-                     ' --jobs=',str(cpus),' ; '
-                     'mv ',consensus_dir,'nextclade.csv ',nextclade_outdir,' ; '
-                     'mv ',consensus_dir,'data/nextclade ',nextclade_outdir,' ; ']
+                     ' --jobs=',str(cpus),' ; ']
 
-    #Move tag file to record which nextclade database tag/version was used
-    nextclade_command += ['mv ',consensus_dir,'/data/sars-cov-2/tag.json ',nextclade_outdir,'/nextclade-tag.json']
+    #Move nextclade results and database information to the nextclade output folder
+    nextclade_command += ['mv ',consensus_dir,'nextclade.csv ',nextclade_outdir,' ; '
+                     'mv ',consensus_dir,'data/nextclade ',nextclade_outdir,' ; '
+                     'mv ',consensus_dir,'/data/sars-cov-2/tag.json ',nextclade_outdir,'/nextclade-tag.json']
 
     print(combineCommand(nextclade_command))
     return nextclade_command


### PR DESCRIPTION
- The file called `tag.json` is now saved from Nextclade to record the Nexclade database/tag that was used (`005_nextclade/nextclade-tag.json`)
    - This file also contains other properties of the dataset used, see [Nextclade datasets](https://docs.nextstrain.org/projects/nextclade/en/stable/user/datasets.html) 
- Pangolin version is already recorded in `lineage_report.csv` (`004_pangolin/linage_report.csv`)
    - This file also contains other things like the Scorpio and Constellations version used, see [Pangolin output](https://cov-lineages.org/resources/pangolin/output.html)